### PR TITLE
API to upload token metadata JSON to IPFS

### DIFF
--- a/app.js
+++ b/app.js
@@ -66,15 +66,9 @@ app.post("/api/upload-json-metadata-to-ipfs", async (req, res) => {
 		shouldPreferSymbol: false,
 		language: "en",
 		tags: ["3D model", "Collectables", "NFT", "Cryptobot"],
-		attributes: [
-			{
-				color_schema: { "": "" },
-				body_parts_type: { "": "" },
-			},
-		],
 		externalUri: "https://cryptocodeschool.in/tezos/",
-		artifactUri: artifactURI,
-		displayUri: displayURI,
+		artifactUri: `ipfs://${artifactURI}`,
+		displayUri: `ipfs://${displayURI}`,
 	};
 
 	const URL = "https://api.pinata.cloud/pinning/pinJSONToIPFS";

--- a/app.js
+++ b/app.js
@@ -50,10 +50,10 @@ app.use(express.json());
 app.use(morgan("tiny"));
 
 app.post("/api/upload-json-metadata-to-ipfs", async (req, res) => {
-	const { artifactURI, displayURI } = req.body;
-	if (!artifactURI || !displayURI) {
+	const { artifactURI, displayURI, tokenID } = req.body;
+	if (!artifactURI || !displayURI || !tokenID) {
 		res.status(400).json({
-			error: "artifactURI or displayURI is missing.",
+			error: "artifactURI, displayURI, or tokenID is missing.",
 		});
 	}
 	const metadata = {
@@ -69,6 +69,7 @@ app.post("/api/upload-json-metadata-to-ipfs", async (req, res) => {
 		externalUri: "https://cryptocodeschool.in/tezos/",
 		artifactUri: `ipfs://${artifactURI}`,
 		displayUri: `ipfs://${displayURI}`,
+		tokenId: tokenID,
 	};
 
 	const URL = "https://api.pinata.cloud/pinning/pinJSONToIPFS";

--- a/app.js
+++ b/app.js
@@ -52,10 +52,18 @@ app.use(morgan("tiny"));
 app.post("/api/upload-image-to-ipfs", async (req, res) => {
 	const botImg = req.files.file.data;
 
+	const buffer = Buffer.from(botImg, "base64");
+	const readable = new Readable();
+	readable._read = () => {}; // _read is required but you can noop it
+	readable.push(buffer);
+	readable.push(null);
+	console.log(readable);
 	const form = new FormData();
 	form.append("file", botImg, {
-		filename: "image.png",
+		filename: "cryptobot.png",
 	});
+
+	// console.log(new Image(botImg));
 
 	const url = "https://api.pinata.cloud/pinning/pinFileToIPFS";
 
@@ -91,7 +99,6 @@ app.post("/api/upload-image-to-ipfs", async (req, res) => {
 
 app.post("/api/upload-3d-model-to-ipfs", async (req, res) => {
 	//   console.log(req.body);
-	//   console.log(req.files.file.data);
 
 	// Compress 3d model
 	const bot = await processGlb(req.files.file.data, glbCompressionOptions);

--- a/app.js
+++ b/app.js
@@ -49,7 +49,6 @@ app.use(express.json());
 // logging middleware
 app.use(morgan("tiny"));
 
-
 app.post("/api/upload-json-metadata-to-ipfs", async (req, res) => {
 	const { artifactURI, displayURI } = req.body;
 	if (!artifactURI || !displayURI) {
@@ -100,7 +99,6 @@ app.post("/api/upload-image-to-ipfs", async (req, res) => {
 	form.append("file", botImg, {
 		filename: "cryptobot.png",
 	});
-
 
 	// console.log(new Image(botImg));
 

--- a/app.js
+++ b/app.js
@@ -49,6 +49,49 @@ app.use(express.json());
 // logging middleware
 app.use(morgan("tiny"));
 
+app.post("/api/upload-json-metadata-to-ipfs", async (req, res) => {
+	const { artifactURI, displayURI } = req.body;
+	if (!artifactURI || !displayURI) {
+		res.status(400).json({
+			error: "artifactURI or displayURI is missing.",
+		});
+	}
+	const metadata = {
+		name: "3D Cryptobot",
+		symbol: "CB",
+		decimals: 0,
+		description: "NFT 3d cryptobot",
+		isBooleanAmount: true,
+		isTransferable: true,
+		shouldPreferSymbol: false,
+		language: "en",
+		tags: ["3D model", "Collectables", "NFT", "Cryptobot"],
+		attributes: [
+			{
+				color_schema: { "": "" },
+				body_parts_type: { "": "" },
+			},
+		],
+		externalUri: "https://cryptocodeschool.in/tezos/",
+		artifactUri: artifactURI,
+		displayUri: displayURI,
+	};
+
+	const URL = "https://api.pinata.cloud/pinning/pinJSONToIPFS";
+	const result = await axios.post(URL, metadata, {
+		headers: {
+			pinata_api_key: PINATA_API_KEY,
+			pinata_secret_api_key: PINATA_SECRET_API_KEY,
+		},
+	});
+	const data = await result.data;
+
+	res.json({
+		ipfsHash: data.IpfsHash,
+		timestamp: data.Timestamp,
+	});
+});
+
 app.post("/api/upload-image-to-ipfs", async (req, res) => {
 	const botImg = req.files.file.data;
 

--- a/app.js
+++ b/app.js
@@ -49,6 +49,46 @@ app.use(express.json());
 // logging middleware
 app.use(morgan("tiny"));
 
+app.post("/api/upload-image-to-ipfs", async (req, res) => {
+	const botImg = req.files.file.data;
+
+	const form = new FormData();
+	form.append("file", botImg, {
+		filename: "image.png",
+	});
+
+	const url = "https://api.pinata.cloud/pinning/pinFileToIPFS";
+
+	var config = {
+		method: "post",
+		url: url,
+		maxBodyLength: Infinity,
+		headers: {
+			pinata_api_key: PINATA_API_KEY,
+			pinata_secret_api_key: PINATA_SECRET_API_KEY,
+			...form.getHeaders(),
+		},
+		data: form,
+	};
+
+	try {
+		const output = await axios(config);
+
+		res.send({
+			success: true,
+			body: {
+				ipfsHash: output.data.IpfsHash,
+				timestamp: output.data.Timestamp,
+			},
+		});
+	} catch (err) {
+		res.status(400).send({
+			success: false,
+			error: "Error uploading bot image to IPFS",
+		});
+	}
+});
+
 app.post("/api/upload-3d-model-to-ipfs", async (req, res) => {
 	//   console.log(req.body);
 	//   console.log(req.files.file.data);
@@ -113,8 +153,8 @@ app.listen(port, async () => {
 		add the data for chapters and modules to the DB.
 	*/
 
-	await sequelize.sync({ force: true });
-	await addChapter(Module, Chapter);
+	await sequelize.sync({ alter: true });
+	// await addChapter(Module, Chapter);
 	// await User.create({xtzAddress: '', email: '', verified: true})
 
 	console.log("Lezzz go 🚀");


### PR DESCRIPTION
**What does this PR do?**
Implements the API which uploads token metadata to IPFS.
Takes this json body as input - 

```
{
  "artifactURI": <ipfs_hash_of_3d_model>,
  "displayURI": <ipfs_hash_of_image>
}
```

and pins it to IPFS using Pinata.

Question for @bhaskarSingh :
Currently it embeds just the IPFS hash in the metadata. 
Should it embed the whole IPFS url like - `https://cloudflare-ipfs/ipfs/<hash>` or is just the hash enough?
